### PR TITLE
Require minSdkVersion 17.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   dependencies {
     classpath 'com.android.tools.build:gradle:2.2.3'
-    classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.8'
+    classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.10'
   }
 
   repositories {

--- a/demomode-sample/build.gradle
+++ b/demomode-sample/build.gradle
@@ -6,7 +6,7 @@ android {
 
   defaultConfig {
     applicationId "com.nightlynexus.demomodesample"
-    minSdkVersion 16
+    minSdkVersion 17
     targetSdkVersion 25
     versionCode 1
     versionName "1.0"

--- a/demomode/build.gradle
+++ b/demomode/build.gradle
@@ -7,7 +7,7 @@ android {
   buildToolsVersion "25.0.2"
 
   defaultConfig {
-    minSdkVersion 15
+    minSdkVersion 17
   }
 
   lintOptions {
@@ -25,5 +25,5 @@ repositories {
 }
 
 dependencies {
-  compile 'com.android.support:support-annotations:25.2.0'
+  compile 'com.android.support:support-annotations:25.3.1'
 }

--- a/demomode/src/main/java/com/nightlynexus/demomode/RealDemoModeInitializer.java
+++ b/demomode/src/main/java/com/nightlynexus/demomode/RealDemoModeInitializer.java
@@ -46,7 +46,7 @@ final class RealDemoModeInitializer implements DemoModeInitializer {
     return null;
   }
 
-  @TargetApi(JELLY_BEAN_MR1) @Override public DemoModeSetting getDemoModeSetting() {
+  @Override public DemoModeSetting getDemoModeSetting() {
     ContentResolver resolver = context.getContentResolver();
     String setting = Settings.Global.getString(resolver, SYSTEMUI_DEMO_ALLOWED);
     if (setting == null) {
@@ -55,7 +55,7 @@ final class RealDemoModeInitializer implements DemoModeInitializer {
     return setting.equals("0") ? DISABLED : ENABLED;
   }
 
-  @TargetApi(JELLY_BEAN_MR1) @Override
+  @Override
   public GrantPermissionResult setDemoModeSetting(DemoModeSetting setting) {
     if (setting == getDemoModeSetting()) {
       return SUCCESS;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip


### PR DESCRIPTION
Some helper APIs need 17, and everyone should be minSdkVersion 19 by
now, anyway.

BREAKING CHANGE.